### PR TITLE
Refactoring

### DIFF
--- a/pyclpa/base.py
+++ b/pyclpa/base.py
@@ -1,8 +1,12 @@
 # coding: utf8
 from __future__ import unicode_literals, print_function, division
-from collections import Counter
+import re
+import logging
 
-from pyclpa.util import load_alias, load_whitelist, find_token, load_normalized
+import attr
+from clldutils.text import strip_chars
+
+from pyclpa.util import load_alias, load_whitelist, split
 
 
 _clpa = None
@@ -15,6 +19,20 @@ def get_clpa():
     return _clpa
 
 
+@attr.s
+class Sound(object):
+    id = attr.ib(convert=lambda v: v or '?')
+    clpa = attr.ib(convert=lambda v: v or '?')
+    frequency = attr.ib(default=1)
+    custom = attr.ib(default=False)
+
+
+@attr.s
+class Errors(object):
+    convertible = attr.ib(default=0)
+    non_convertible = attr.ib(default=0)
+
+
 class CLPA(object):
     def __init__(self,
                  whitelist=None,
@@ -25,71 +43,84 @@ class CLPA(object):
                  accents=None,
                  rules=None,
                  normalized=None):
-        self.whitelist = whitelist or load_whitelist()
-        self.alias = alias or load_alias('alias.tsv')
-        self.delete = delete or ['\u0361', '\u035c', '\u0301']
-        self.explicit = explicit or load_alias('explicit.tsv')
-        self.patterns = patterns or load_alias('patterns.tsv')
-        self.accents = accents or "ˈˌ'"
-        self.rules = rules or []
-        self.normalized=normalized or load_normalized('normalized.tsv')
+        self.whitelist = load_whitelist() if whitelist is None else whitelist
+        self.alias = load_alias('alias.tsv') if alias is None else alias
+        self.delete = ['\u0361', '\u035c', '\u0301'] if delete is None else delete
+        self.explicit = load_alias('explicit.tsv') if explicit is None else explicit
+        self.patterns = load_alias('patterns.tsv') if patterns is None else patterns
+        self.accents = "ˈˌ'" if accents is None else accents
+        self.rules = rules or {}
+        self.normalized = load_alias('normalized.tsv') \
+            if normalized is None else normalized
+
+        log = logging.getLogger(__name__)
+        for v in self.explicit.values():
+            if v not in self.whitelist:
+                log.debug('explicit token "{0}" not in whitelist'.format(v))
 
     def check_sequence(self, seq, sounds=None, errors=None):
-        if not isinstance(seq, (list, tuple)):
-            new_seq = seq.split(' ')
-        else:
-            new_seq = [x for x in seq]
-        if self.rules:
-            new_seq = [self.rules[t] if t in self.rules else t for t in new_seq]
+        seq = seq if isinstance(seq, (list, tuple)) else split(seq)
+        tokens = []
+        sounds = {} if sounds is None else sounds
+        errors = errors or Errors()
 
-        new_tokens = []
-        sounds = sounds or {}
-        errors = errors or Counter({
-            'convertable': 0, 
-            'non-convertable': 0,
-            'custom' : 0})
-
-        for token in new_seq:
+        for token in [self.rules.get(t, t) for t in seq]:
             accent = ''
             if token[0] in self.accents:
                 accent, token = token[0], token[1:]
 
-            if token in self.whitelist or token in sounds:
-                if token in sounds:
-                    sounds[token]['frequency'] += 1
-                else:
-                    sounds[token] = dict(
-                        frequency=1, clpa=token, id=self.whitelist[token]['ID'])
-            elif token[-1] == '/' and len(token) > 1:
-                tkn = token[:-1]
-                if token in sounds:
-                    sounds[token]['frequency'] += 1
-                else:
-                    idf = 'custom:{0}'.format(tkn)
-                    sounds[token] = dict(
-                            frequency=1, clpa='*'+tkn, id=idf)
-                    errors.update(['custom'])
+            if token in sounds:
+                sounds[token].frequency += 1
+            elif token in self.whitelist:
+                sounds[token] = Sound(clpa=token, id=self.whitelist[token]['ID'])
+            elif token.endswith('/') and len(token) > 1:
+                sounds[token] = Sound(
+                    custom=True, clpa='*' + token[:-1], id='custom:%s' % token[:-1])
             else:
-                check = find_token(
-                    token, self.whitelist, self.alias, self.explicit,
-                    self.patterns, self.delete)
-                sounds[token] = dict(
-                    frequency=1,
-                    clpa=check if check else '?',
-                    id=self.whitelist[check]['ID'] if check else '?')
-                errors.update(['convertable' if check else 'non-convertable'])
+                tkn, id_ = self._find(token)
+                sounds[token] = Sound(clpa=tkn, id=id_)
+                if tkn:
+                    errors.convertible += 1
+                else:
+                    errors.non_convertible += 1
 
-            new_tokens.append(accent + sounds[token]['clpa'])
-        return new_tokens, sounds, errors
+            tokens.append(accent + sounds[token].clpa)
+        return tokens, sounds, errors
 
     def segment2clpa(self, segment):
         """Convert a segment to its identifier"""
-        if segment[0] in self.accents:
-            new_segment = segment[1:]
-        else:
-            new_segment = segment
-        return self.whitelist[new_segment]['ID'] \
-            if new_segment in self.whitelist else '?'
+        segment = segment[1:] if segment[0] in self.accents else segment
+        return self.whitelist[segment]['ID'] if segment in self.whitelist else '?'
 
     def normalize(self, string):
         return ''.join([self.normalized.get(x, x) for x in string])
+
+    def _find(self, token):
+        # custom symbols, indicated by "/", in the form "custom/value", if value is
+        # missing, this will be subsumed under "custom" in the count
+        if '/' in token and len(token) > 1:
+            _, token = token.split('/', 1)
+            assert token  # note: the custom case "c/" has been dealt with already!
+
+        # first run, delete useless stuff
+        token = strip_chars(self.delete, token)
+        if token in self.whitelist:
+            return token, self.whitelist[token]['ID']
+
+        # second run, explicit match
+        if token in self.explicit:
+            assert self.explicit[token] in self.whitelist
+            return self.explicit[token], self.whitelist[self.explicit[token]]['ID']
+
+        # third run, replace
+        token = ''.join([self.alias.get(t, t) for t in token])
+        if token in self.whitelist:
+            return token, self.whitelist[token]['ID']
+
+        # forth run, pattern matching
+        for source, target in self.patterns.items():
+            token = re.sub(source, target, token)
+            if token in self.whitelist:
+                return token, self.whitelist[token]['ID']
+
+        return None, None

--- a/pyclpa/cli.py
+++ b/pyclpa/cli.py
@@ -4,19 +4,37 @@ Main command line interface to the pyclpa package.
 """
 from __future__ import unicode_literals, print_function
 import sys
-from collections import defaultdict, OrderedDict
+from collections import OrderedDict
+import argparse
 
-from clldutils.clilib import ArgumentParser, ParserError
+from clldutils.clilib import ArgumentParser, ParserError, command
 from clldutils.path import Path
 from clldutils.dsv import UnicodeWriter
+from clldutils.markup import Table
 
 from pyclpa.util import check_string, load_whitelist
 from pyclpa.wordlist import Wordlist
 
 
-def report(args):
+def _checked_wordlist_from_args(args):
+    if len(args.args) != 1:
+        raise ParserError('no input file specified')
+
+    fname = Path(args.args[0])
+    if not fname.exists():
+        raise ParserError('invalid input file specified')
+
+    wordlist = Wordlist.from_file(fname, delimiter=args.delimiter)
+    sounds, errors = wordlist.check(rules=args.rules, column=args.column)
+    return wordlist, sounds, errors
+
+
+@command()
+def annotate(args):
     """
-    clpa report <FILE> [rules=FILE] [format=md|csv|cldf] [outfile=FILENAME]
+    Will add two columns CLPA_TOKENS and CLPA_IDS to the input file.
+
+    clpa annotate <FILE>
 
     Note
     ----
@@ -25,87 +43,80 @@ def report(args):
       given to convert a segment to another segment to be applied on a
       data-set-specific basis which may vary from dataset to dataset and can thus
       not be included as standard clpa behaviour.
-    * Input file needs to be in csv-format, with tabstop as separator, and it
-      needs to contain one column named "TOKENS".
+    * Input file needs to be in csv-format with header, delimiter and name of the
+      relevant column can be specified as --delimiter and --column options respectively.
+    * The resulting CSV is printed to <stdout> or to the file specified as --output.
+
+    """
+    wordlist, _, _ = _checked_wordlist_from_args(args)
+    res = wordlist.write(args.output)
+    if args.output is None:
+        print(res)
+
+
+@command()
+def report(args):
+    """
+    clpa report <FILE>
+
+    Note
+    ----
+
+    * Rules point to a tab-separated value file in which source and target are
+      given to convert a segment to another segment to be applied on a
+      data-set-specific basis which may vary from dataset to dataset and can thus
+      not be included as standard clpa behaviour.
+    * Input file needs to be in csv-format with header, delimiter and name of the
+      relevant column can be specified as --delimiter and --column options respectively.
     * format now allows for md (MarkDown), csv (CSV, tab as separator), or cldf
       (no pure cldf but rather current lingpy-csv-format). CLDF format means
       that the original file will be given another two columns, one called
       CLPA_TOKENS, one called CLPA_IDS.
-    * if you specify an outfile from the input, the data will be written to
-      file instead showing it on the screen.
+    * The report is printed to <stdout> or to the file specified as --output.
 
     """
-    if len(args.args) < 1:
-        raise ParserError('not enough arguments')
-
-    # get keywords from arguments @xrotwang: is there any better way to do so?
-    settings = defaultdict(str)
-    settings['format'] = 'md'
-    fname = None
-    for arg in args.args:
-        if '=' in arg:
-            key, val = arg.split('=')
-            settings[key] = val
-        else:
-            fname = arg
-
-    if not fname:
-        raise ParserError('no filename passed as argument')
-
-    wordlist = Wordlist.from_file(fname)
-    sounds, errors = wordlist.check(rules=settings['rules'])
-
-    if settings['format'] not in ['md', 'csv']:
-        text = wordlist.write(settings['outfile'] or None)
-        if not settings['outfile']:
-            print(text)
-        return
+    wordlist, sounds, errors = _checked_wordlist_from_args(args)
 
     segments = OrderedDict([('existing', []), ('missing', []), ('convertible', [])])
     for k in sorted(
-        sounds, key=lambda x: (sounds[x]['frequency'], sounds[x]['id']), reverse=True
-    ):
+            sounds, key=lambda x: (sounds[x].frequency, sounds[x].id), reverse=True):
         type_, symbol = None, None
-        if k == sounds[k]['clpa']:
+        if k == sounds[k].clpa:
             type_, symbol = 'existing', k
-        elif sounds[k]['clpa'] == '?':
+        elif sounds[k].clpa == '?':
             type_, symbol = 'missing', k
         else:
-            check = sounds[k]['clpa']
+            check = sounds[k].clpa
             if k != check != '?':
-                type_, symbol = 'convertible', k + ' >> ' + sounds[k]['clpa']
+                type_, symbol = 'convertible', k + ' >> ' + sounds[k].clpa
         if type_ and symbol:
-            segments[type_].append([symbol, sounds[k]['id'], sounds[k]['frequency']])
+            segments[type_].append([symbol, sounds[k].id, sounds[k].frequency])
 
-    if settings['format'] == 'csv':
-        with UnicodeWriter(settings['outfile'] or None, delimiter='\t') as writer:
+    if args.format == 'csv':
+        with UnicodeWriter(args.output, delimiter='\t') as writer:
             for key, items in segments.items():
                 for i, item in enumerate(items):
                     writer.writerow([i + 1] + item + [key])
-        if not settings['outfile']:
+        if args.output is None:
             print(writer.read())
         return
 
-    text = []
-    header_template = """
-# {0} sounds
-
-| number | sound | clpa | frequency |
-| ------:| ----- | ---- | ---------:|"""
-
+    res = []
     for key, items in segments.items():
-        text.append(header_template.format(key.capitalize()))
+        sounds = Table('number', 'sound', 'clpa', 'frequency')
         for i, item in enumerate(items):
-            text.append("| {0} | {1[0]} | {1[1]} | {1[2]} |".format(i + 1, item))
-
-    text = '\n'.join(text)
-    if settings['outfile']:
-        with Path(settings['outfile']).open('w', encoding='utf8') as fp:
-            fp.write(text)
+            sounds.append([i + 1] + item)
+        res.append('\n# {0} sounds\n\n{1}'.format(
+            key.capitalize(), sounds.render(condensed=False)))
+    res = '\n'.join(res)
+    if args.output:
+        with Path(args.output).open('w', encoding='utf8') as fp:
+            fp.write(res)
     else:
-        print(text)
+        print(res)
 
 
+@command()
 def check(args):
     """
     clpa check <STRING>
@@ -117,6 +128,30 @@ def check(args):
     print('\t'.join(check))
 
 
-def main():  # pragma: no cover
-    parser = ArgumentParser('pyclpa', report, check)
-    sys.exit(parser.main())
+def main(args=None):
+    parser = ArgumentParser('pyclpa', formatter_class=argparse.RawTextHelpFormatter)
+    parser.add_argument(
+        "-d", "--delimiter",
+        help="Delimiting character of the input file.\n(default: <tab>)",
+        default="\t")
+    parser.add_argument(
+        "-o", "--output",
+        help="Output file.",
+        default=None)
+    parser.add_argument(
+        "-r", "--rules",
+        help="Rules file.",
+        default=None)
+    parser.add_argument(
+        "-c", "--column",
+        help="Delimiting character of the input file.\n(default: TOKENS)",
+        default="TOKENS")
+    parser.add_argument(
+        "--format",
+        help="Output format for the report.\n(default: md)",
+        choices=['md', 'csv', 'cldf'],
+        default="md")
+
+    res = parser.main(args=args)
+    if args is None:  # pragma: no cover
+        sys.exit(res)

--- a/pyclpa/tests/test_base.py
+++ b/pyclpa/tests/test_base.py
@@ -10,30 +10,68 @@ class Tests(TestCase):
         self.clpa = get_clpa()
         self.clpa2 = CLPA(rules=dict(th='t'))
 
+    def test_normalize(self):
+        self.assertEqual(self.clpa.normalize('a \u01dd'), 'a \u0259')
+
     def test_check_sequence(self):
-        test1 = self.clpa.check_sequence(['t', 'e', 's', 't'])
-        assert '?' not in test1[0]
-        test2 = self.clpa.check_sequence('t e s t')
-        assert '?' not in test2[0]
-        test3 = self.clpa.check_sequence('t e th s t')
-        assert test3[0][2][1] == 'ʰ'
-        test4 = self.clpa.check_sequence('t X s t')
-        assert test4[0][1] == '?'
-        test5 = self.clpa.check_sequence('ˈt e s t')
-        assert test5[0][0][1] == 't'
-        test6 = self.clpa2.check_sequence('th e')
-        assert test6[0][0] == 't'
-        test7 = self.clpa.check_sequence('p h₂ t e r')
-        assert ' '.join(test7[0]) == 'p ? t e r'
-        test8 = self.clpa.check_sequence('p h₂/ t e r')
-        assert ' '.join(test8[0]) == 'p *h₂ t e r'
-        assert test8[2]['custom'] == 1
-        test9 = self.clpa.check_sequence('p h₂/x t e r')
-        assert ' '.join(test9[0]) == 'p x t e r'
-        assert 'h₂/x' in test9[1]
+        tokens, sounds, errors = self.clpa.check_sequence(['t', 'e', 's', 't'])
+        assert '?' not in tokens
+
+        tokens, sounds, errors = self.clpa.check_sequence('t e s t')
+        assert '?' not in tokens
+
+        tokens, sounds, errors = self.clpa.check_sequence('t e th s t')
+        assert tokens[2][1] == 'ʰ'
+
+        tokens, sounds, errors = self.clpa.check_sequence('t X s t')
+        assert tokens[1] == '?'
+
+        tokens, sounds, errors = self.clpa.check_sequence('ˈt e s t')
+        assert tokens[0][1] == 't'
+
+        tokens, sounds, errors = self.clpa2.check_sequence('th e')
+        assert tokens[0] == 't'
+
+        tokens, sounds, errors = self.clpa.check_sequence('p h₂ t e r')
+        assert ' '.join(tokens) == 'p ? t e r'
+
+        tokens, sounds, errors = self.clpa.check_sequence('p h₂/ t e r')
+        assert ' '.join(tokens) == 'p *h₂ t e r'
+        self.assertEqual(sum(1 for s in sounds.values() if s.custom), 1)
+
+        tokens, sounds, errors = self.clpa.check_sequence('p h₂/x t e r')
+        assert ' '.join(tokens) == 'p x t e r'
+        assert 'h₂/x' in sounds
+
         # test for bad custom characters
-        test10 = self.clpa.check_sequence('p / t e r')
-        assert ' '.join(test10[0]) == 'p ? t e r'
+        tokens, sounds, errors = self.clpa.check_sequence('p / t e r')
+        assert ' '.join(tokens) == 'p ? t e r'
+
+    def test_find_token(self):
+        from pyclpa.util import load_whitelist, load_alias
+
+        def _find(token, **kw):
+            for k in [
+                    'whitelist', 'alias', 'explicit', 'patterns', 'rules', 'normalized']:
+                kw.setdefault(k, {})
+            kw.setdefault('delete', [])
+            return CLPA(**kw)._find(token)[0]
+
+        wl = load_whitelist()
+        patterns = load_alias('patterns.tsv')
+
+        self.assertIsNone(_find('t'))
+        self.assertEqual(_find('t', whitelist=wl), 't')
+        self.assertEqual(_find('t', whitelist=wl), 't')
+        self.assertEqual(_find('th', whitelist=wl, alias={'h': 'ʰ'}), 'tʰ')
+        self.assertEqual(_find('th', whitelist=wl, explicit={'th': 'x'}), 'x')
+
+        with self.assertRaises(AssertionError):
+            _find('th', whitelist=wl, explicit={'th': 'X'})
+
+        self.assertEqual(_find('th', whitelist=wl, patterns=patterns), 'tʰ')
+        self.assertEqual(_find('th', whitelist=wl, delete=['h']), 't')
+        self.assertEqual(_find('x/t', whitelist=wl), 't')
 
     def test_segment2clpa(self):
         assert self.clpa.segment2clpa('t') == 'c118'

--- a/pyclpa/tests/test_util.py
+++ b/pyclpa/tests/test_util.py
@@ -30,17 +30,3 @@ class Tests(TestCase):
 
         check = check_string('m a tt i s', load_whitelist())
         assert check[2] == '?'
-
-    def test_find_token(self):
-        from pyclpa.util import find_token, load_whitelist, load_alias
-
-        wl = load_whitelist()
-        patterns = load_alias('patterns.tsv')
-        assert not find_token('t', {}, {}, {}, {}, [])
-        assert find_token('t', wl, {}, {}, {}, []) == 't'
-        assert find_token('th', wl, {'h': 'ʰ'}, {}, {}, []) == 'tʰ'
-        assert find_token('th', wl, {}, {'th': 'x'}, {}, []) == 'x'
-        with self.assertRaises(ValueError):
-            find_token('th', wl, {}, {'th': 'X'}, {}, [])
-        assert find_token('th', wl, {}, {}, patterns, []) == 'tʰ'
-        assert find_token('th', wl, {}, {}, {}, ['h']) == 't'

--- a/pyclpa/tests/test_wordlist.py
+++ b/pyclpa/tests/test_wordlist.py
@@ -24,9 +24,9 @@ class Tests(TestCase):
     def test_check_wordlist(self):
         wl = self._make_one()
         sounds, errors = wl.check()
-        assert errors['convertable'] == 13
-        assert errors['non-convertable'] == 4
-        assert sounds['t']['frequency'] == 223
+        assert errors.convertible == 13
+        assert errors.non_convertible == 4
+        assert sounds['t'].frequency == 223
 
         sounds, errors = wl.check(rules=self.data_path('KSL.rules'))
-        assert errors['non-convertable'] == 3
+        assert errors.non_convertible == 3

--- a/pyclpa/util.py
+++ b/pyclpa/util.py
@@ -63,18 +63,6 @@ def load_alias(_path):
                 alias[eval('"' + source + '"')] = eval('r"' + target + '"')
     return alias
 
-def load_normalized(_path):
-    """Normalization for quasi-identical strings which are often confused."""
-    path = Path(_path)
-    if not path.is_file():
-        path = local_path(_path)
-    norms = {}
-    with path.open(encoding='utf-8') as handle:
-        for line in handle:
-            if not line.startswith('#') and line.strip():
-                source, target = line.strip().split('\t')
-                norms[eval('"' + source + '"')] = eval('r"' + target + '"')
-    return norms
 
 def split(string):
     return string.split(' ')
@@ -87,53 +75,3 @@ def join(tokens):
 def check_string(seq, whitelist):
     return [
         '*' if t in whitelist else '?' for t in split(unicodedata.normalize('NFC', seq))]
-
-
-def find_token(token, whitelist, alias, explicit, patterns, delete):
-    if token in whitelist:
-        return token
-    
-    # custom symbols, indicated by "/", in the form "custom/value", if value is
-    # missing, this will be subsumed under "custom" in the count
-    if '/' in token and len(token) > 1:
-        custom, value = token.split('/')
-        if not value:
-            return token
-        token = value
-
-    # first run, delete useless stuff
-    tokens = list(token)
-    for i, t in enumerate(tokens):
-        if t in delete:
-            tokens[i] = ''
-    new_token = ''.join(tokens)
-    if new_token in whitelist:
-        return new_token
-
-    # third run, explicit match
-    if new_token in explicit:
-        new_token = explicit[new_token]
-        if new_token in whitelist:
-            return new_token
-        raise ValueError(
-            "Explicit list does not point to whitelist with sound «{0}»".format(
-                new_token))
-
-    # second run, replace
-    tokens = list(new_token)
-    for i, t in enumerate(tokens):
-        if t in alias:
-            tokens[i] = alias[t]
-
-    new_token = ''.join(tokens)
-    if new_token in whitelist:
-        return new_token
-
-    # forth run, pattern matching
-    for source, target in patterns.items():
-        search = re.search(source, new_token)
-        if search:
-            new_token = re.sub(source, target, new_token)
-        if new_token in whitelist:
-            return new_token
-    return False

--- a/pyclpa/wordlist.py
+++ b/pyclpa/wordlist.py
@@ -1,29 +1,28 @@
 # coding: utf8
 from __future__ import unicode_literals, print_function, division
 import unicodedata
-from collections import Counter
 
 from clldutils.path import Path
 from clldutils.dsv import reader, UnicodeWriter
 
 from pyclpa.util import load_alias, split, join
-from pyclpa.base import get_clpa
+from pyclpa.base import get_clpa, Errors
 
 
 class Wordlist(list):
     @classmethod
-    def from_file(cls, path, sep="\t", comment="#"):
+    def from_file(cls, path, delimiter="\t", comment="#"):
         wl = cls()
-        wl.read(path, sep=sep, comment=comment)
+        wl.read(path, delimiter=delimiter, comment=comment)
         return wl
 
-    def read(self, path, sep="\t", comment="#"):
+    def read(self, path, delimiter="\t", comment="#"):
         with Path(path).open(encoding='utf-8') as handle:
             lines = [unicodedata.normalize('NFC', hline) for hline in handle.readlines()
                      if hline and not hline.startswith(comment)]
-        self.extend(list(reader(lines, dicts=True, delimiter=sep)))
+        self.extend(list(reader(lines, dicts=True, delimiter=delimiter)))
 
-    def write(self, path, sep="\t"):
+    def write(self, path=None, sep="\t"):
         with UnicodeWriter(path, delimiter=sep) as writer:
             for i, item in enumerate(self):
                 if i == 0:
@@ -41,15 +40,11 @@ class Wordlist(list):
                 tokens = [rules[t] if t in rules else t for t in split(val[column])]
                 val[column] = join(tokens)
 
-        sounds, errors = {}, Counter({'convertable': 0, 'non-convertable': 0})
+        sounds, errors = {}, Errors()
         for item in self:
-            new_tokens, sounds, errors = clpa.check_sequence(
+            tokens, _, _ = clpa.check_sequence(
                 split(item[column]), sounds=sounds, errors=errors)
-            idxs = [clpa.segment2clpa(t) for t in new_tokens]
-
-            #    new_tokens.append(accent + sounds[token]['clpa'])
-            #    idxs.append(sounds[token]['id'])
-            item['CLPA_TOKENS'] = join(new_tokens)
-            item['CLPA_IDS'] = join(idxs)
+            item['CLPA_TOKENS'] = join(tokens)
+            item['CLPA_IDS'] = join([clpa.segment2clpa(t) for t in tokens])
 
         return sounds, errors

--- a/setup.py
+++ b/setup.py
@@ -14,9 +14,10 @@ setup(
     author_email='mattis.list@lingpy.org',
     url='https://github.com/glottobank/cpa',
     install_requires=[
-        'clldutils',
+        'attrs',
+        'clldutils>=1.7',
     ],
-    include_package_data = True,
+    include_package_data=True,
     license="GPL",
     zip_safe=False,
     keywords='',


### PR DESCRIPTION
- moved `util.find_token` to method `CLPA._find` and cut it down to the cases
  not handled at the point where it is called.
- turned command options into global options of the main cli. This is a bit
  unfortunate but considering that `report` is **the** main subcommand seems
  acceptable.
- factored out "inline reporting" to new cli command `annotate`.